### PR TITLE
TF GCP Provider 4.0.0 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ resource "google_kms_key_ring" "sctl" {
 module "cloud-ops-operational-key" {
   source = "github.com/vapor-ware/sctl-gcp"
 
-  keyring = google_kms_key_ring.sctl.self_link
+  keyring = google_kms_key_ring.sctl.id
   key = "infra-secrets"
   owners = [
     "admin@example.com",

--- a/main.tf
+++ b/main.tf
@@ -12,14 +12,14 @@ resource "google_kms_crypto_key" "key" {
 resource "google_kms_crypto_key_iam_binding" "owners" {
   role = "roles/owner"
 
-  crypto_key_id = google_kms_crypto_key.key.self_link
+  crypto_key_id = google_kms_crypto_key.key.id
 
   members = compact(var.owners)
 }
 
 resource "google_kms_crypto_key_iam_binding" "decrypters" {
   role          = "roles/cloudkms.cryptoKeyDecrypter"
-  crypto_key_id = google_kms_crypto_key.key.self_link
+  crypto_key_id = google_kms_crypto_key.key.id
 
   members = compact(var.decrypters)
 }
@@ -27,7 +27,7 @@ resource "google_kms_crypto_key_iam_binding" "decrypters" {
 resource "google_kms_crypto_key_iam_binding" "encrypters" {
   role = "roles/cloudkms.cryptoKeyEncrypter"
 
-  crypto_key_id = google_kms_crypto_key.key.self_link
+  crypto_key_id = google_kms_crypto_key.key.id
 
   members = compact(var.encrypters)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,5 +36,5 @@ variable "key_rotation_period" {
 
 output "key_uri" {
   description = "GCP KMS Key Uri"
-  value       = google_kms_crypto_key.key.self_link
+  value       = google_kms_crypto_key.key.id
 }


### PR DESCRIPTION
The self_link attribute has been deprecated in favor of `id`